### PR TITLE
Add buffered `heartbeat_buffer` event

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,7 @@ async function captureHeartbeat(timestamp: string) {
 
 /** Capture `heartbeat` event, directly into the queue, but with a random distinct ID so that it goes via buffer */
 async function captureHeartbeatBuffer(timestamp: string) {
-    const randomDistinctId = `PostHog Heartbeat Plugin / Buffer ${Math.random().toString().slice(2)}`
+    const randomDistinctId = `PostHog Heartbeat Plugin / Buffer ${Date.now()}`
     await posthog.capture('heartbeat_buffer', { $timestamp: timestamp, distinct_id: randomDistinctId })
 }
 

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,9 @@ export async function runEveryMinute({ config }) {
     if (eventsArray.includes('heartbeat')) {
         capturePromises.push(captureHeartbeat(timestamp))
     }
+    if (eventsArray.includes('heartbeat_buffer')) {
+        capturePromises.push(captureHeartbeatBuffer(timestamp))
+    }
     if (eventsArray.includes('heartbeat_api')) {
         if (!config.host) {
             throw new Error('PostHog host needs to be configured for heartbeat_api to work!')
@@ -29,6 +32,12 @@ export async function runEveryMinute({ config }) {
 /** Capture `heartbeat` event, directly into the queue */
 async function captureHeartbeat(timestamp: string) {
     await posthog.capture('heartbeat', { $timestamp: timestamp })
+}
+
+/** Capture `heartbeat` event, directly into the queue, but with a random distinct ID so that it goes via buffer */
+async function captureHeartbeatBuffer(timestamp: string) {
+    const randomDistinctId = `PostHog Heartbeat Plugin / Buffer ${Math.random().toString().slice(2)}`
+    await posthog.capture('heartbeat_buffer', { $timestamp: timestamp, distinct_id: randomDistinctId })
 }
 
 /** Capture `heartbeat_api` event, via the API */

--- a/plugin.json
+++ b/plugin.json
@@ -11,7 +11,7 @@
             "name": "Events to be emitted",
             "type": "choice",
             "hint": "The basic `heartbeat` event emitted by this plugin goes straight into the event ingestion queue. The `heartbeat_api` event goes via the event capture endpoint, which helps monitor the API too.",
-            "choices": ["heartbeat", "heartbeat_api", "heartbeat + heartbeat_api"],
+            "choices": ["heartbeat", "heartbeat_api", "heartbeat + heartbeat_buffer + heartbeat_api"],
             "default": "heartbeat",
             "required": true
         },


### PR DESCRIPTION
Adds heartbeat event that should always go via event buffer. Will make for an ingestion via buffer lag metric.